### PR TITLE
debug in get_disk_info()

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -50,7 +50,8 @@ def get_disk_info():
     for disk in disks:
         row = disk.split()
         if row[filesystem_index].startswith('/'):
-            st = os.statvfs(row[mounted_on_index])
+            #st = os.statvfs(row[mounted_on_index]) causes an error with a disk name contining white spaces
+            st = os.statvfs(" ".join(row[mounted_on_index:])) 
             disk_info.append({
                 'mount': row[mounted_on_index],
                 'size': calculate_human_readable_filesize(st.f_frsize * st.f_blocks),


### PR DESCRIPTION
自分の環境(macOS)ではブラウザからアクセスしたときに下記エラーが起きたので修正しました．
良ければ取り込んでください．
同様に，ブラウザでロードしたときに'Mounted on'のdisk名が切れてしまうバグもありますが，こちらは表示の問題でしかないので，直してません．

% ./run.sh 
[INFO] Starting CSLAIER server on localhost:8080
Traceback (most recent call last):
（略）
  File "/Users/user/Downloads/CSLAIER/src/common/utils.py", line 53, in get_disk_info
    st = os.statvfs(row[mounted_on_index])
OSError: [Errno 2] No such file or directory: '/Volumes/RAM'

githubの使い方を学習中なのでおかしなことしていたらすみません．
Pull Requestしてみるのも初めてです．